### PR TITLE
feat: Implementace vícejazyčného načítání kategorií

### DIFF
--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from 'next/navigation';
 export async function generateStaticParams() {
   const [articles, categories] = await Promise.all([
     getBlogArticles(),
-    getBlogCategories(),
+    getBlogCategories('cs'), // Použijeme češtinu pro generování statických parametrů
   ]);
 
   const articleParams = articles.flatMap((article) => [
@@ -29,7 +29,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ lang: string; slug: string }> }): Promise<Metadata> {
   const { lang, slug } = await params;
   const locale = isValidLocale(lang) ? lang : 'cs';
-  const category = await getCategoryBySlug(slug);
+  const category = await getCategoryBySlug(slug, locale);
   const article = category ? null : await getArticleBySlug(slug);
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://expandmatrix.com';
 
@@ -66,11 +66,11 @@ export default async function ArticleOrCategoryPage({ params }: { params: Promis
   const { lang, slug } = await params;
   const locale: Locale = isValidLocale(lang) ? lang : 'cs';
 
-  const category = await getCategoryBySlug(slug);
+  const category = await getCategoryBySlug(slug, locale);
   if (category) {
     const dict = await getDictionary(locale);
     const [categories, articles] = await Promise.all([
-      getBlogCategories(),
+      getBlogCategories(locale),
       getBlogArticles(category.slug),
     ]);
 

--- a/app/[lang]/blog/category/[category]/page.tsx
+++ b/app/[lang]/blog/category/[category]/page.tsx
@@ -5,7 +5,7 @@ import BlogContent from '@/components/blog/BlogContent';
 import { notFound } from 'next/navigation';
 
 export async function generateStaticParams() {
-  const categories = await getBlogCategories();
+  const categories = await getBlogCategories('cs'); // Použijeme češtinu pro generování statických parametrů
   const params = [];
   
   for (const lang of ['cs', 'en']) {
@@ -27,7 +27,7 @@ export async function generateMetadata({
   const { lang, category } = await params;
   const locale = isValidLocale(lang) ? lang : 'cs';
   
-  const categoryData = await getCategoryBySlug(category);
+  const categoryData = await getCategoryBySlug(category, locale);
   if (!categoryData) {
     return {};
   }
@@ -58,14 +58,14 @@ export default async function CategoryPage({
   const locale = isValidLocale(lang) ? lang : 'cs';
   const dict = await getDictionary(locale);
   
-  const categoryData = await getCategoryBySlug(category);
+  const categoryData = await getCategoryBySlug(category, locale);
   if (!categoryData || !categoryData.isActive) {
     notFound();
   }
 
   // Načteme data na serveru
   const [categories, articles] = await Promise.all([
-    getBlogCategories(),
+    getBlogCategories(locale),
     getBlogArticles(category)
   ]);
 

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -41,7 +41,7 @@ export default async function BlogPage({
   
   // Načteme data na serveru
   const [categories, articles] = await Promise.all([
-    getBlogCategories(),
+    getBlogCategories(locale),
     getBlogArticles()
   ]);
 

--- a/lib/blogApi.ts
+++ b/lib/blogApi.ts
@@ -26,13 +26,13 @@ export interface BlogArticle {
 }
 
 // API funkce pro kategorie
-export async function getBlogCategories(): Promise<BlogCategory[]> {
+export async function getBlogCategories(locale: string = 'en'): Promise<BlogCategory[]> {
   // Žádné fallback kategorie - načítáme pouze z CMS
   const fallbackCategories: BlogCategory[] = [];
 
   try {
-    console.log('Načítám kategorie ze Strapi CMS...');
-    const strapiCategories = await strapiApi.getCategories();
+    console.log(`Načítám kategorie ze Strapi CMS pro jazyk: ${locale}...`);
+    const strapiCategories = await strapiApi.getCategories(locale);
     console.log('Strapi kategorie:', strapiCategories);
     
     if (!strapiCategories || !Array.isArray(strapiCategories)) {
@@ -208,7 +208,7 @@ export async function getArticleBySlug(slug: string): Promise<BlogArticle | null
   }
 }
 
-export async function getCategoryBySlug(slug: string): Promise<BlogCategory | null> {
-  const categories = await getBlogCategories();
+export async function getCategoryBySlug(slug: string, locale: string = 'en'): Promise<BlogCategory | null> {
+  const categories = await getBlogCategories(locale);
   return categories.find(cat => cat.slug === slug) || null;
 }

--- a/lib/strapiApi.ts
+++ b/lib/strapiApi.ts
@@ -205,10 +205,11 @@ class StrapiAPI {
   }
 
   // Get all categories
-  async getCategories(): Promise<Category[]> {
-    const response = await this.request<any>(
-      '/categories?sort=name:asc'
-    );
+  async getCategories(locale: string = 'en'): Promise<Category[]> {
+    // Určíme endpoint podle jazyka
+    const endpoint = locale === 'cs' ? '/kategories?sort=name:asc' : '/categories?sort=name:asc';
+    
+    const response = await this.request<any>(endpoint);
 
     // Strapi vrací data v jednoduchém formátu, ne ve vnořené struktuře
     return response.data.map((category: any) => ({


### PR DESCRIPTION
- Upravena strapiApi.ts pro načítání z různých tabulek podle jazyka
- Pro češtinu se načítá z tabulky 'kategories'
- Pro angličtinu se načítá z tabulky 'categories'
- Přidán parametr locale do getBlogCategories() a getCategoryBySlug()
- Aktualizovány všechny komponenty pro předávání správného jazyka
- Testováno pro oba jazyky - funguje správně

Technické změny:
- lib/strapiApi.ts: Přidán parametr locale do getCategories()
- lib/blogApi.ts: Přidán parametr locale do getBlogCategories() a getCategoryBySlug()
- app/[lang]/blog/page.tsx: Předávání locale do getBlogCategories()
- app/[lang]/blog/[slug]/page.tsx: Předávání locale do obou funkcí
- app/[lang]/blog/category/[category]/page.tsx: Předávání locale do obou funkcí